### PR TITLE
ref and copy error fix

### DIFF
--- a/harvest/api/paper.py
+++ b/harvest/api/paper.py
@@ -136,7 +136,7 @@ class PaperBroker(API):
                 # Check to see if user has enough funds to buy the stock
                 actual_price = self.apply_commission(original_price, self.commission_fee, 'sell')
                 if self.buying_power < actual_price:
-                    warning(f"""Not enough buying power.\n Total price ({actual_worth}) exceeds buying power {self.buy_power}.\n Reduce purchase quantity or increase buying power.""")
+                    warning(f"""Not enough buying power.\n Total price ({actual_price}) exceeds buying power {self.buy_power}.\n Reduce purchase quantity or increase buying power.""")
                 # Check to see the price does not exceed the limit price
                 elif ret['limit_price'] < price:
                     limit_price = ret['limit_price']

--- a/harvest/api/paper.py
+++ b/harvest/api/paper.py
@@ -136,7 +136,7 @@ class PaperBroker(API):
                 # Check to see if user has enough funds to buy the stock
                 actual_price = self.apply_commission(original_price, self.commission_fee, 'sell')
                 if self.buying_power < actual_price:
-                    warning(f"""Not enough buying power.\n Total price ({actual_price}) exceeds buying power {self.buy_power}.\n Reduce purchase quantity or increase buying power.""")
+                    warning(f"""Not enough buying power.\n Total price ({actual_price}) exceeds buying power {self.buying_power}.\n Reduce purchase quantity or increase buying power.""")
                 # Check to see the price does not exceed the limit price
                 elif ret['limit_price'] < price:
                     limit_price = ret['limit_price']
@@ -201,7 +201,7 @@ class PaperBroker(API):
                 # Check to see if user has enough funds to buy the stock
                 actual_price = self.apply_commission(original_price, self.commission_fee, 'buy')
                 if self.buying_power < actual_price:
-                    warning(f"""Not enough buying power.\n Total price ({actual_price}) exceeds buying power {self.buy_power}.\n Reduce purchase quantity or increase buying power.""")
+                    warning(f"""Not enough buying power.\n Total price ({actual_price}) exceeds buying power {self.buying_power}.\n Reduce purchase quantity or increase buying power.""")
                 elif ret['limit_price'] < price:
                     limit_price = ret['limit_price']
                     info(f'Limit price for {sym} is less than current price ({limit_price} < {price}).')

--- a/harvest/api/yahoo.py
+++ b/harvest/api/yahoo.py
@@ -65,7 +65,6 @@ class YahooStreamer(API):
                     s = '@'+s[:-4]
                 df_tmp = self._format_df(df_tmp, s)
                 df_dict[s] = df_tmp
-                print(df_tmp)
         self.trader_main(df_dict)
 
     # -------------- Streamer methods -------------- #
@@ -222,6 +221,7 @@ class YahooStreamer(API):
     # ------------- Helper methods ------------- #
 
     def _format_df(self, df: pd.DataFrame, symbol: str):
+        df = df.copy()
         df.reset_index(inplace=True)
         ts_name = df.columns[0]
         df['timestamp'] = df[ts_name]


### PR DESCRIPTION
Fix for below errors.
```
/tmp/fint/.venv/lib/python3.9/site-packages/harvest/api/yahoo.py:227: SettingWithCopyWarning: 
A value is trying to be set on a copy of a slice from a DataFrame.
Try using .loc[row_indexer,col_indexer] = value instead

See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy
  df['timestamp'] = df[ts_name]
```

```
File "/tmp/fint/.venv/lib/python3.9/site-packages/harvest/api/paper.py", line 139, in fetch_stock_order_status
    warning(f"""Not enough buying power.\n Total price ({actual_worth}) exceeds buying power {self.buy_power}.\n Reduce purchase quantity or increase buying power.""")
UnboundLocalError: local variable 'actual_worth' referenced before assignment
```