### PR TITLE
updated to only run on releases

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,8 +4,8 @@
 name: Deploy package to PyPI
 
 on:
-  push:
-    branches: [ main ]
+  release:
+    types: [ published ]
 
 jobs:
   build:


### PR DESCRIPTION
The current deployment workflow will build and update the pypi package on every push to main. This changes it so that the package is updated on ever release instead,