### PR TITLE
Code cleanup

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -37,6 +37,9 @@ jobs:
       shell: bash
       env:
         POLYGON_API_KEY: ${{secrets.POLYGON_API_KEY}}
+    
+    - name: Set ENV
+      run: 'export GITHUB_ACTION=TRUE'
 
     - name: Run tests
       run: |

--- a/harvest/algo.py
+++ b/harvest/algo.py
@@ -198,11 +198,12 @@ class BaseAlgo:
         """
         Automatically buys an option that satisfies the criteria specified.
 
-        :param str type: 'call' or 'put'
         :param str? symbol: Symbol of stock. defaults to first symbol in watchlist
-        :param datetime limit_exp: Minimum expiration date of the option. defaults to 5 days from current day
-        :param float limit_strike: For calls, sets the minimum strike price of the option - for puts, the maximum. 
-            defaults to current stock price
+        :param str? type: 'call' or 'put'
+        :param datetime lower_exp: Minimum expiration date of the option. 
+        :param datetime upper_exp: Maximum expiration date of the option. 
+        :param float lower_strike: The minimum strike price of the option
+        :param float upper_strike: The maximum strike price of the option
 
         """
         if symbol is None:

--- a/harvest/storage/base_storage.py
+++ b/harvest/storage/base_storage.py
@@ -1,3 +1,4 @@
+from numpy import ERR_CALL
 import pandas as pd
 import datetime as dt
 from threading import Lock
@@ -30,7 +31,7 @@ class BaseStorage:
         """
         self.storage_lock = Lock()
         self.storage = {}
-        self.queue_size = queue_size
+        self.queue_size = int(queue_size)
         self.limit_size = limit_size
 
     def store(self, symbol: str, interval: str, data: pd.DataFrame, remove_duplicate=True) -> None:
@@ -60,7 +61,7 @@ class BaseStorage:
                 try:
                     # Handles if we have stock data for the given interval
                     intervals[interval] = self._append(intervals[interval], data, remove_duplicate=remove_duplicate)
-                    intervals[interval] = intervals[interval][-self.N:]
+                    intervals[interval] = intervals[interval][-self.queue_size:]
                 except:
                     raise Exception('Append Failure, case not found!')
             else:
@@ -68,8 +69,8 @@ class BaseStorage:
                 intervals[interval] = data
         else:
             if self.limit_size:
-                data = data[-self.N:]
-            if len(data) < self.N:
+                data = data[-self.queue_size:]
+            if len(data) < self.queue_size:
                 warning(f"Symbol {symbol}, interval {interval} initialized with only {len(data)} data points")
             # Just add the data into storage
             self.storage[symbol] = {
@@ -77,7 +78,7 @@ class BaseStorage:
             }
             
         cur_len = len(self.storage[symbol][interval])
-        if self.limit_size and cur_len > int(self.queue_size):
+        if self.limit_size and cur_len > self.queue_size:
             # If we have more than N data points, remove the oldest data
             self.storage[symbol][interval] = self.storage[symbol][interval].iloc[-self.queue_size:]
 

--- a/harvest/storage/base_storage.py
+++ b/harvest/storage/base_storage.py
@@ -2,7 +2,7 @@ import pandas as pd
 import datetime as dt
 from threading import Lock
 from typing import Tuple
-from logging import debug
+from logging import debug, warning
 import re
 
 from harvest.utils import *
@@ -54,23 +54,28 @@ class BaseStorage:
         self.storage_lock.acquire()
 
         if symbol in self.storage:
-            # Handles if we already have stock data
+            # Handles if we already have data
             intervals = self.storage[symbol]
             if interval in intervals:
                 try:
                     # Handles if we have stock data for the given interval
                     intervals[interval] = self._append(intervals[interval], data, remove_duplicate=remove_duplicate)
+                    intervals[interval] = intervals[interval][-self.N:]
                 except:
                     raise Exception('Append Failure, case not found!')
             else:
                 # Add the data as a new interval
                 intervals[interval] = data
         else:
+            if self.limit_size:
+                data = data[-self.N:]
+            if len(data) < self.N:
+                warning(f"Symbol {symbol}, interval {interval} initialized with only {len(data)} data points")
             # Just add the data into storage
             self.storage[symbol] = {
                 interval: data
             }
-
+            
         cur_len = len(self.storage[symbol][interval])
         if self.limit_size and cur_len > int(self.queue_size):
             # If we have more than N data points, remove the oldest data

--- a/harvest/storage/base_storage.py
+++ b/harvest/storage/base_storage.py
@@ -72,7 +72,7 @@ class BaseStorage:
             }
 
         cur_len = len(self.storage[symbol][interval])
-        if self.limit_size and cur_len > self.queue_size:
+        if self.limit_size and cur_len > int(self.queue_size):
             # If we have more than N data points, remove the oldest data
             self.storage[symbol][interval] = self.storage[symbol][interval].iloc[-self.queue_size:]
 

--- a/harvest/storage/pickle_storage.py
+++ b/harvest/storage/pickle_storage.py
@@ -16,7 +16,7 @@ class PickleStorage(BaseStorage):
     An extension of the basic storage that saves data in pickle files.
     """
 
-    def __init__(self, queue_size=200, limit_size=True, save_dir: str='data'):
+    def __init__(self, save_dir: str='data', queue_size:int=200, limit_size:bool=True):
         super().__init__(queue_size, limit_size)
         """
         Adds a directory to save data to. Loads any data that is currently in the

--- a/harvest/storage/pickle_storage.py
+++ b/harvest/storage/pickle_storage.py
@@ -16,8 +16,8 @@ class PickleStorage(BaseStorage):
     An extension of the basic storage that saves data in pickle files.
     """
 
-    def __init__(self, save_dir: str='data'):
-        super().__init__()
+    def __init__(self, queue_size=200, limit_size=True, save_dir: str='data'):
+        super().__init__(queue_size, limit_size)
         """
         Adds a directory to save data to. Loads any data that is currently in the
         directory.

--- a/harvest/trader/tester.py
+++ b/harvest/trader/tester.py
@@ -28,7 +28,6 @@ class BackTester(trader.Trader):
     def __init__(self, streamer=None, config={}):      
         """Initializes the TestTrader. 
         """
-        self.N = 200
         
         if streamer == None:
             self.streamer = YahooStreamer()
@@ -38,8 +37,7 @@ class BackTester(trader.Trader):
 
         self.watch = []             # List of stocks to watch
 
-        self.storage = PickleStorage()  # local cache of historic price
-        self.storage.N = self.N
+        self.storage = PickleStorage(limit_size=False)  # local cache of historic price
 
         self.account = {}           # Local cash of account info 
 
@@ -227,6 +225,7 @@ class BackTester(trader.Trader):
         self.storage.limit_size = True
         
         rows = len(self.df[interval][self.watch[0]].index)
+        print("Rows", rows)
         for i in range(rows):
             df_dict = {}
             for s in self.watch:

--- a/harvest/trader/tester.py
+++ b/harvest/trader/tester.py
@@ -225,7 +225,6 @@ class BackTester(trader.Trader):
         self.storage.limit_size = True
         
         rows = len(self.df[interval][self.watch[0]].index)
-        print("Rows", rows)
         for i in range(rows):
             df_dict = {}
             for s in self.watch:

--- a/harvest/trader/trader.py
+++ b/harvest/trader/trader.py
@@ -1,16 +1,13 @@
 # Builtins
-import asyncio
 import re
 import threading
 from logging import warning, debug
 import sys
-from signal import signal, SIGINT, SIGABRT
 from sys import exit
+from signal import signal, SIGINT
 import time
-import datetime as dt
 
 # External libraries
-import pandas as pd
 
 # Submodule imports
 from harvest.utils import *
@@ -38,8 +35,7 @@ class Trader:
         """
         signal(SIGINT, self.exit)
 
-        self.N = 200
-
+        # Harvest only supports Python 3.8 or newer.
         if sys.version_info[0] < 3 or sys.version_info[1] < 8:
             raise Exception("Harvest requires Python 3.8 or above.")
 
@@ -57,34 +53,36 @@ class Trader:
         else:
             self.broker = broker
 
-        # Initialize date 
         self.timestamp_prev = now()
         self.timestamp = self.timestamp_prev
 
-        self.watch = []             # List of stocks to watch
-        self.account = {}           # Local cash of account info 
+        self.watch = []             # Watchlist of securities.
+        self.account = {}           # Local cache of account data.
 
-        self.stock_positions = []   # Local cache of current stock positions
-        self.option_positions = []  # Local cache of current options positions
-        self.crypto_positions = []  # Local cache of current crypto positions
+        self.stock_positions = []   # Local cache of current stock positions.
+        self.option_positions = []  # Local cache of current options positions.
+        self.crypto_positions = []  # Local cache of current crypto positions.
 
-        self.order_queue = []       # Queue of unfilled orders
+        self.order_queue = []       # Queue of unfilled orders.
 
         if storage is None:
-            self.storage = BaseStorage() # Storage to hold stock/crypto data
+            self.storage = BaseStorage() 
         else:
-            self.storage = storage
-        
-        self.storage.N = self.N
-        
+            self.storage = storage                
         self.logger = BaseLogger()
 
-        self.block_lock = threading.Lock() # Lock for streams that recieve data asynchronously
+        self.block_lock = threading.Lock() # Lock for streams that receive data asynchronously.
 
         self.algo = []
         self.is_save = False
 
-    def setup(self, interval, aggregations, sync=True):
+    def _setup(self, interval, aggregations, sync=True):
+        """
+        Initializes data and parameters necessary to run the program.
+        :param str interval: Interval to run the algorithm.
+        :param str List(str) aggregations: List of intervals to aggregate the data.
+        :param bool sync: If True, fetches any open positions and orders from the specified broker. 
+        """
         self.sync = sync
         self.interval = interval
         self.aggregations = aggregations
@@ -100,11 +98,10 @@ class Trader:
                 raise Exception(f"""Interval '{interval}' is greater than aggregation interval '{agg}'\n
                                     All intervals in aggregations must be greater than specified interval '{interval}'""")
 
-        # Instantiate the account
+        # Initialize the account
         self._setup_account()
 
-        # If sync is on, call the broker to load pending orders and 
-        # all positions currently held.
+        # If sync is on, call the broker to load pending orders and all positions currently held.
         print(f"Sync: {sync}")
         if sync:
             self._setup_stats()
@@ -118,9 +115,9 @@ class Trader:
                 self.watch.append(s['symbol'])     
 
         if len(self.watch) == 0:
-            raise Exception(f"No stock or crypto was specified.")
+            raise Exception(f"No securities were added to watchlist")
 
-        # Remove duplicates
+        # Remove duplicates in watchlist
         self.watch = list(set(self.watch))
         print(f"Watchlist: {self.watch}")
 
@@ -147,9 +144,6 @@ class Trader:
         for s in self.watch:
             for i in [self.fetch_interval] + self.aggregations:
                 df = self.streamer.fetch_price_history(s, i)
-                df = df.iloc[-self.N:]
-                if df_len := len(df) < self.N:
-                    warning(f"Symbol {s}, interval {i} initialized with only {df_len} data points")
                 self.storage.store(s, i, df)
 
     def _setup_account(self):
@@ -195,7 +189,7 @@ class Trader:
 
         self.broker.setup(self.watch, interval, self, self.main)
         self.streamer.setup(self.watch, interval, self, self.main)
-        self.setup(interval, aggregations, sync)
+        self._setup(interval, aggregations, sync)
 
         print(f"Initializing algorithms...")
         for a in self.algo:
@@ -211,8 +205,6 @@ class Trader:
         self.needed = self.watch.copy()
 
         self.is_save = True
-        
-        self.loop = asyncio.get_event_loop()
 
         self.streamer.start(kill_switch)
 

--- a/tests/test_paper_broker.py
+++ b/tests/test_paper_broker.py
@@ -69,15 +69,6 @@ class TestPaperBroker(unittest.TestCase):
         self.assertEqual(status['time_in_force'], 'gtc')
         self.assertEqual(status['status'], 'filled')
     
-    def test_await_buy(self):
-        broker = PaperBroker() 
-        broker.streamer = DummyStreamer()
-        broker.setup(['A'], '1MIN')
-        stat = 'filled'
-        broker.fetch_crypto_order_status = lambda x: {'status': stat}
-        order = broker.await_buy('A', 5)
-        self.assertEqual(order['symbol'], 'A')
-
     def test_sell_order_limit(self):
         directory = pathlib.Path(__file__).parent.resolve()
         dummy = PaperBroker(str(directory) + '/../dummy_account.yaml') 

--- a/tests/test_polygon_streamer.py
+++ b/tests/test_polygon_streamer.py
@@ -1,16 +1,18 @@
 # Builtins
 import unittest
 import datetime as dt
+import os
 
 from harvest.utils import *
 from harvest.api.polygon import PolygonStreamer
 
 class TestPolygonStreamer(unittest.TestCase):
     def test_fetch_prices(self):
+        if not 'GITHUB_ACTION' in os.environ:
+            return 
         poly = PolygonStreamer('poly_secret.yaml', True)
         df = poly.fetch_price_history('AAPL', '1HR', now() - dt.timedelta(days=7), now())['AAPL']
         self.assertEqual(list(df.columns.values), ['open', 'high', 'low', 'close', 'volume'])
-
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR, aside from some cleanup, makes three changes:
- Proposes a convention of prepending a '__' to API class subclass attribute names, to make it explicit that they are not part of common attributes defined in the API class. 
- Updates the test so API class tests are only run when `GITHUB_ACTION` ENV variable is defined. This is helpful since otherwise users who don't have accounts for services like Polygon or Robinhood will not be able to pass those tests when running tests locally. 
- Removed `await_buy` and `await_sell`. They were already disabled some time ago as it did not seem to be a useful function. This PR removes them completely. 