### PR TITLE
Updated interface

### DIFF
--- a/examples/backtest.py
+++ b/examples/backtest.py
@@ -3,7 +3,6 @@ from harvest.trader import BackTester
 
 
 class BackTest(BaseAlgo):
-
     def config(self):
         self.watchlist = ["SPY"]
         self.interval = "5MIN"

--- a/examples/crossover.py
+++ b/examples/crossover.py
@@ -3,7 +3,6 @@ from harvest.trader import Trader
 
 
 class Crossover(BaseAlgo):
-
     def config(self):
         self.watchlist = ["SPY"]
         self.interval = "5MIN"

--- a/examples/crypto.py
+++ b/examples/crypto.py
@@ -10,8 +10,8 @@ It also demonstrates some built-in functions.
 # Constants
 N = 3
 
-class Crypto(BaseAlgo):
 
+class Crypto(BaseAlgo):
     def config(self):
         self.watchlist = ["@DOGE"]
         self.interval = "30MIN"
@@ -97,7 +97,8 @@ class Crypto(BaseAlgo):
     def sell_eval(self, ret):
         return bool(ret > self.cutoff + 0.02 or ret < self.cutoff - 0.001)
 
+
 if __name__ == "__main__":
     t = Trader(Robinhood(), PaperBroker())
     t.set_algo(Crypto())
-    t.start() 
+    t.start()

--- a/examples/monitor.py
+++ b/examples/monitor.py
@@ -5,14 +5,15 @@ from harvest.algo import BaseAlgo
 from harvest.trader import Trader
 from harvest.api.robinhood import Robinhood
 
-class Watch(BaseAlgo):
 
+class Watch(BaseAlgo):
     def config(self):
-        self.watchlist = ['@BTC']
+        self.watchlist = ["@BTC"]
         self.interval = "1MIN"
 
     def main(self):
         print(self.get_asset_price())
+
 
 if __name__ == "__main__":
     t = Trader(Robinhood())

--- a/examples/options.py
+++ b/examples/options.py
@@ -11,7 +11,6 @@ introducing option-related functions.
 
 
 class Option(BaseAlgo):
-
     def config(self):
         self.watchlist = ["SPY"]
         self.interval = "5MIN"
@@ -64,6 +63,7 @@ class Option(BaseAlgo):
         print(f"BUY: {occ}")
 
         self.hold = True
+
 
 if __name__ == "__main__":
     t = Trader(Robinhood())

--- a/examples/simulation.py
+++ b/examples/simulation.py
@@ -9,8 +9,8 @@ from harvest.api.paper import PaperBroker
 # Constants
 N = 3
 
-class Crypto(BaseAlgo):
 
+class Crypto(BaseAlgo):
     def config(self):
         self.watchlist = ["@ETH"]
         self.interval = "1MIN"
@@ -25,6 +25,7 @@ class Crypto(BaseAlgo):
             self.sell()
         else:
             self.buy()
+
 
 if __name__ == "__main__":
     t = Trader(debug=True)

--- a/harvest/algo.py
+++ b/harvest/algo.py
@@ -757,7 +757,9 @@ class BaseAlgo:
 
         :returns: The current date and time as a datetime object
         """
-        return datetime_utc_to_local(self.trader.streamer.timestamp, self.trader.timezone)
+        return datetime_utc_to_local(
+            self.trader.streamer.timestamp, self.trader.timezone
+        )
 
     def get_option_position_quantity(self, symbol: str = None) -> bool:
         """Returns the number of types of options held for a stock.

--- a/harvest/algo.py
+++ b/harvest/algo.py
@@ -246,6 +246,8 @@ class BaseAlgo:
         """
         if symbol is None:
             symbol = self.watchlist[0]
+        lower_exp = _convert_input_to_datetime(lower_exp)
+        upper_exp = _convert_input_to_datetime(upper_exp)
 
         exp_dates = self.get_option_chain_info(symbol)["exp_dates"]
         if lower_exp is not None:
@@ -282,7 +284,7 @@ class BaseAlgo:
             symbol = self.watchlist[0]
         return self.trader.fetch_chain_info(symbol)
 
-    def get_option_chain(self, symbol: str, date: dt.datetime):
+    def get_option_chain(self, symbol: str, date):
         """Returns the option chain for the specified symbol and expiration date.
 
         :param str symbol: symbol of stock
@@ -297,6 +299,7 @@ class BaseAlgo:
         """
         if symbol is None:
             symbol = self.watchlist[0]
+        date = _convert_input_to_datetime(date)
         return self.trader.fetch_chain_data(symbol, date)
 
     def get_option_market_data(self, symbol: str):

--- a/harvest/algo.py
+++ b/harvest/algo.py
@@ -296,6 +296,7 @@ class BaseAlgo:
             - type(str): 'call' or 'put'
 
         The index is the {OCC} symbol of the option.
+        Note that the expiration date is not adjusted to the local time zone.
         """
         if symbol is None:
             symbol = self.watchlist[0]
@@ -603,7 +604,8 @@ class BaseAlgo:
         if interval is None:
             interval = self.interval
         if len(symbol) <= 6:
-            return self.trader.storage.load(symbol, interval).iloc[[-1]][symbol]
+            df = self.trader.storage.load(symbol, interval).iloc[[-1]][symbol]
+            return pandas_timestamp_to_local(df, self.trader.timezone)
         debugger.warning("Candles not available for options")
         return None
 
@@ -631,7 +633,8 @@ class BaseAlgo:
             symbol = self.watchlist[0]
         if interval is None:
             interval = self.interval
-        return self.trader.storage.load(symbol, interval)[symbol]
+        df = self.trader.storage.load(symbol, interval)[symbol]
+        return pandas_timestamp_to_local(df, self.trader.timezone)
 
     def get_asset_returns(self, symbol=None) -> float:
         """Returns the return of a specified asset.
@@ -754,7 +757,7 @@ class BaseAlgo:
 
         :returns: The current date and time as a datetime object
         """
-        return self.trader.timestamp.replace(tzinfo=None)
+        return datetime_utc_to_local(self.trader.streamer.timestamp, self.trader.timezone)
 
     def get_option_position_quantity(self, symbol: str = None) -> bool:
         """Returns the number of types of options held for a stock.

--- a/harvest/api/yahoo.py
+++ b/harvest/api/yahoo.py
@@ -96,7 +96,7 @@ class YahooStreamer(API):
                 )
                 debugger.debug(f"From yfinance got: {df_tmp}")
                 df = df_tmp if df is None else df.join(df_tmp)
-            
+
             if len(df.index) == 0:
                 return
             for s in combo:
@@ -108,7 +108,7 @@ class YahooStreamer(API):
                     s = "@" + s[:-4]
                 df_tmp = self._format_df(df_tmp, s)
                 df_dict[s] = df_tmp
-        
+
         debugger.debug(f"From yfinance dict: {df_dict}")
         self.trader_main(df_dict)
 

--- a/harvest/api/yahoo.py
+++ b/harvest/api/yahoo.py
@@ -69,7 +69,9 @@ class YahooStreamer(API):
 
         if len(combo) == 1:
             s = combo[0]
-            interval_fmt = self.fmt_interval(self.interval[self.unfmt_symbol(s)]["interval"])
+            interval_fmt = self.fmt_interval(
+                self.interval[self.unfmt_symbol(s)]["interval"]
+            )
             df = yf.download(s, period="1d", interval=interval_fmt, prepost=True)
             debugger.debug(f"From yfinance got: {df}")
             if len(df.index) == 0:

--- a/harvest/api/yahoo.py
+++ b/harvest/api/yahoo.py
@@ -81,7 +81,7 @@ class YahooStreamer(API):
             df_dict[s] = df
         else:
             names = " ".join(combo)
-            df = pd.DataFrame()
+            df = None
             required_intervals = {}
             for s in combo:
                 i = self.interval[self.unfmt_symbol(s)]["interval"]
@@ -94,8 +94,9 @@ class YahooStreamer(API):
                 df_tmp = yf.download(
                     names, period="1d", interval=self.fmt_interval(i), prepost=True
                 )
-                df = df.join(df_tmp)
-            debugger.debug(f"From yfinance got: {df}")
+                debugger.debug(f"From yfinance got: {df_tmp}")
+                df = df_tmp if df is None else df.join(df_tmp)
+            
             if len(df.index) == 0:
                 return
             for s in combo:
@@ -107,6 +108,8 @@ class YahooStreamer(API):
                     s = "@" + s[:-4]
                 df_tmp = self._format_df(df_tmp, s)
                 df_dict[s] = df_tmp
+        
+        debugger.debug(f"From yfinance dict: {df_dict}")
         self.trader_main(df_dict)
 
     # -------------- Streamer methods -------------- #

--- a/harvest/trader/__init__.py
+++ b/harvest/trader/__init__.py
@@ -1,2 +1,2 @@
-from harvest.trader.trader import Trader
+from harvest.trader.trader import LiveTrader, PaperTrader
 from harvest.trader.tester import BackTester

--- a/harvest/trader/tester.py
+++ b/harvest/trader/tester.py
@@ -30,23 +30,8 @@ class BackTester(trader.Trader):
 
         self.streamer = YahooStreamer() if streamer is None else streamer
         self.broker = PaperBroker()
-
-        self.watchlist_global = []  # List of stocks to watch
-
         self.storage = PickleStorage(limit_size=False)  # local cache of historic price
-
-        self.account = {}  # Local cash of account info
-
-        self.stock_positions = []  # Local cache of current stock positions
-        self.option_positions = []  # Local cache of current options positions
-        self.crypto_positions = []  # Local cache of current crypto positions
-
-        self.order_queue = []  # Queue of unfilled orders
-
-        self.logger = BaseLogger()
-        debugger.debug(
-            f"Streamer: {type(self.streamer).__name__}\nBroker: {type(self.broker).__name__}\nStorage: {type(self.storage).__name__}"
-        )
+        self._init_attributes()
 
         self._setup_debugger(debug)
 

--- a/harvest/trader/tester.py
+++ b/harvest/trader/tester.py
@@ -19,6 +19,7 @@ from harvest.storage import BaseLogger
 from harvest.utils import *
 from harvest.utils import _convert_input_to_datetime, _convert_input_to_timedelta
 
+
 class BackTester(trader.PaperTrader):
     """
     This class replaces several key functions to allow backtesting
@@ -41,9 +42,9 @@ class BackTester(trader.PaperTrader):
         aggregations: List[Any] = [],
         source: str = "PICKLE",
         path: str = "./data",
-        start = None,
-        end = None,
-        period = None,
+        start=None,
+        end=None,
+        period=None,
     ):
         """Runs backtesting.
 
@@ -75,14 +76,14 @@ class BackTester(trader.PaperTrader):
         self.run_backtest()
 
     def _setup(
-        self, 
+        self,
         source: str,
-        interval: str, 
-        aggregations: List, 
-        path: str, 
-        start, 
+        interval: str,
+        aggregations: List,
+        path: str,
+        start,
         end,
-        period
+        period,
     ):
         self._setup_params(interval, aggregations)
         self._setup_account()

--- a/harvest/trader/tester.py
+++ b/harvest/trader/tester.py
@@ -41,9 +41,9 @@ class BackTester(trader.Trader):
         aggregations: List[Any] = [],
         source: str = "PICKLE",
         path: str = "./data",
-        start: str = None,
-        end: str = None,
-        period: str = None,
+        start = None,
+        end = None,
+        period = None,
     ):
         """Runs backtesting.
 
@@ -74,7 +74,16 @@ class BackTester(trader.Trader):
 
         self.run_backtest()
 
-    def _setup(self, source, interval: str, aggregations, path, start, end, period):
+    def _setup(
+        self, 
+        source: str,
+        interval: str, 
+        aggregations: List, 
+        path: str, 
+        start, 
+        end,
+        period
+    ):
         self._setup_params(interval, aggregations)
         self._setup_account()
 
@@ -82,19 +91,18 @@ class BackTester(trader.Trader):
 
         self.storage.limit_size = False
 
-        start = None if start is None else str_to_datetime(start)
-        end = None if end is None else str_to_datetime(end)
-
-        val, unit = expand_string_interval(period) if period is not None else (1, "DAY")
+        start = _convert_input_to_datetime(start, self.timezone)
+        end = _convert_input_to_datetime(end, self.timezone)
+        period = _convert_input_to_timedelta(period)
 
         if start is None and end is None:
             end = self.streamer.current_timestamp()
-            start = end - dt.timedelta(days=val) if period is not None else "MAX"
+            start = end - period if period is not None else "MAX"
         elif start is None:
-            start = end - dt.timedelta(days=val) if period is not None else "MAX"
+            start = end - period if period is not None else "MAX"
         elif end is None:
             end = (
-                start + dt.timedelta(days=val)
+                start + period
                 if period is not None
                 else self.streamer.current_timestamp()
             )

--- a/harvest/trader/tester.py
+++ b/harvest/trader/tester.py
@@ -17,9 +17,9 @@ from harvest.api.yahoo import YahooStreamer
 from harvest.api.paper import PaperBroker
 from harvest.storage import BaseLogger
 from harvest.utils import *
+from harvest.utils import _convert_input_to_datetime, _convert_input_to_timedelta
 
-
-class BackTester(trader.Trader):
+class BackTester(trader.PaperTrader):
     """
     This class replaces several key functions to allow backtesting
     on historical data.

--- a/harvest/trader/trader.py
+++ b/harvest/trader/trader.py
@@ -42,16 +42,18 @@ class LiveTrader:
         self._init_checks()
 
         self._set_streamer_broker(streamer, broker)
-        self.storage = BaseStorage() if storage is None else storage    # Initialize the storage
+        self.storage = (
+            BaseStorage() if storage is None else storage
+        )  # Initialize the storage
         self._init_attributes()
 
         self._setup_debugger(debug)
-    
+
     def _init_checks(self):
         # Harvest only supports Python 3.8 or newer.
         if sys.version_info[0] < 3 or sys.version_info[1] < 8:
             raise Exception("Harvest requires Python 3.8 or above.")
-       
+
     def _set_streamer_broker(self, streamer, broker):
         """Sets the streamer and broker."""
         # If streamer is not specified, use YahooStreamer
@@ -84,6 +86,8 @@ class LiveTrader:
         self.logger = BaseLogger()
         self.server = Server(self)  # Initialize the web interface server
 
+        self.timezone = time.tzname[0]
+
     def _setup_debugger(self, debug):
         # Set up logger
         if debug:
@@ -104,7 +108,7 @@ class LiveTrader:
         :kill_switch: If true, kills the infinite loop in streamer. Primarily used for testing. defaults to False.
 
         """
-        debugger.debug(f"Setting up Harvest...")
+        debugger.debug("Setting up Harvest...")
 
         # If sync is on, call the broker to load pending orders and all positions currently held.
         if sync:
@@ -126,7 +130,7 @@ class LiveTrader:
         self._setup_params(interval, aggregations)
 
         if len(self.interval) == 0:
-            raise Exception(f"No securities were added to watchlist")
+            raise Exception("No securities were added to watchlist")
 
         # Initialize the account
         self._setup_account()
@@ -134,8 +138,7 @@ class LiveTrader:
         self.broker.setup(self.interval, self, self.main)
         if self.broker != self.streamer:
             # Only call the streamer setup if it is a different
-            # instance than the broker otherwise some brokers can
-            # fail!
+            # instance than the broker otherwise some brokers can fail!
             self.streamer.setup(self.interval, self, self.main)
 
         # Initialize the storage
@@ -438,6 +441,7 @@ class LiveTrader:
         debugger.debug("\nStopping Harvest...")
         exit(0)
 
+
 class PaperTrader(LiveTrader):
     """
     A class for trading in the paper trading environment.
@@ -451,9 +455,10 @@ class PaperTrader(LiveTrader):
         # If streamer is not specified, use YahooStreamer
         self.streamer = YahooStreamer() if streamer is None else streamer
         self.broker = PaperBroker()
-        
-        self.storage = BaseStorage() if storage is None else storage    # Initialize the storage
+
+        self.storage = (
+            BaseStorage() if storage is None else storage
+        )  # Initialize the storage
         self._init_attributes()
 
         self._setup_debugger(debug)
-       

--- a/harvest/trader/trader.py
+++ b/harvest/trader/trader.py
@@ -19,7 +19,7 @@ from harvest.storage import BaseLogger
 from harvest.server import Server
 
 
-class Trader:
+class LiveTrader:
     """
     :broker: Both the broker and streamer store a Broker object.
         Broker places orders and retrieves latest account info like equity.
@@ -39,49 +39,50 @@ class Trader:
     def __init__(self, streamer=None, broker=None, storage=None, debug=False):
         """Initializes the Trader."""
 
-        signal(SIGINT, self.exit)
+        self._init_checks()
 
+        self._set_streamer_broker(streamer, broker)
+        self.storage = BaseStorage() if storage is None else storage    # Initialize the storage
+        self._init_attributes()
+
+        self._setup_debugger(debug)
+    
+    def _init_checks(self):
         # Harvest only supports Python 3.8 or newer.
         if sys.version_info[0] < 3 or sys.version_info[1] < 8:
             raise Exception("Harvest requires Python 3.8 or above.")
-
+       
+    def _set_streamer_broker(self, streamer, broker):
+        """Sets the streamer and broker."""
         # If streamer is not specified, use YahooStreamer
         self.streamer = YahooStreamer() if streamer is None else streamer
-        # If broker is not specified and streamer is YahooStreamer, use PaperBroker
+        # Broker must be specified
         if broker is None:
-            if isinstance(self.streamer, (YahooStreamer, DummyStreamer)):
-                self.broker = PaperBroker()
+            # TODO: Raise exception is specified class is streaming only
+            if isinstance(self.streamer, YahooStreamer):
+                raise Exception("Broker must be specified")
             else:
                 self.broker = self.streamer
         else:
             self.broker = broker
 
-        # # Initialize timestamp
+    def _init_attributes(self):
+
+        signal(SIGINT, self.exit)
+
+        # Initialize timestamp
         self.timestamp = self.streamer.timestamp
-        # self.timestamp = self.timestamp_prev
 
-        self.watchlist_global = []  # List of securities specified in this class,
-        # fetched from brokers, and retrieved from Algo class.
-
+        self.watchlist_global = []  # List of securities specified in this class
+        self.algo = []  # List of algorithms to run.
         self.account = {}  # Local cache of account data.
-
         self.stock_positions = []  # Local cache of current stock positions.
         self.option_positions = []  # Local cache of current options positions.
         self.crypto_positions = []  # Local cache of current crypto positions.
-
         self.order_queue = []  # Queue of unfilled orders.
 
-        # Initialize the storage
-        self.storage = BaseStorage() if storage is None else storage
-
         self.logger = BaseLogger()
-
-        self._setup_debugger(debug)
-
-        self.algo = []  # List of algorithms to run.
-
-        # Initialize the web interface server
-        self.server = Server(self)
+        self.server = Server(self)  # Initialize the web interface server
 
     def _setup_debugger(self, debug):
         # Set up logger
@@ -436,3 +437,23 @@ class Trader:
         # TODO: Gracefully exit
         debugger.debug("\nStopping Harvest...")
         exit(0)
+
+class PaperTrader(LiveTrader):
+    """
+    A class for trading in the paper trading environment.
+    """
+
+    def __init__(self, streamer=None, storage=None, debug=False):
+        """Initializes the Trader."""
+
+        self._init_checks()
+
+        # If streamer is not specified, use YahooStreamer
+        self.streamer = YahooStreamer() if streamer is None else streamer
+        self.broker = PaperBroker()
+        
+        self.storage = BaseStorage() if storage is None else storage    # Initialize the storage
+        self._init_attributes()
+
+        self._setup_debugger(debug)
+       

--- a/harvest/trader/trader.py
+++ b/harvest/trader/trader.py
@@ -7,6 +7,7 @@ from signal import signal, SIGINT
 import time
 
 # External libraries
+import tzlocal
 
 # Submodule imports
 from harvest.utils import *
@@ -86,7 +87,8 @@ class LiveTrader:
         self.logger = BaseLogger()
         self.server = Server(self)  # Initialize the web interface server
 
-        self.timezone = time.tzname[0]
+        self.timezone = tzlocal.get_localzone()
+        debugger.debug(f"Timezone: {self.timezone}")
 
     def _setup_debugger(self, debug):
         # Set up logger

--- a/harvest/utils.py
+++ b/harvest/utils.py
@@ -5,7 +5,7 @@ import time
 import random
 import logging
 import datetime as dt
-from datetime import timezone as tz 
+from datetime import timezone as tz
 from enum import IntEnum, auto
 from zoneinfo import ZoneInfo
 
@@ -106,6 +106,7 @@ def interval_to_timedelta(interval: Interval) -> dt.timedelta:
     params = {expanded_units[unit]: value}
     return dt.timedelta(**params)
 
+
 def is_crypto(symbol: str) -> bool:
     return symbol[0] == "@"
 
@@ -144,17 +145,21 @@ def now() -> dt.datetime:
     """
     return dt.datetime.now(tz.utc).replace(microsecond=0, second=0)
 
+
 def epoch_zero() -> dt.datetime:
     """
     Returns a datetime object corresponding to midnight 1/1/1970 UTC
     """
     return dt.datetime(1970, 1, 1, tzinfo=tz.utc)
 
+
 def date_to_str(day) -> str:
     return day.strftime("%Y-%m-%d")
 
+
 def str_to_date(day) -> str:
     return dt.datetime.strptime(day, "%Y-%m-%d")
+
 
 def str_to_datetime(date: str) -> dt.datetime:
     """
@@ -164,14 +169,18 @@ def str_to_datetime(date: str) -> dt.datetime:
         return dt.datetime.strptime(date, "%Y-%m-%d")
     return dt.datetime.strptime(date, "%Y-%m-%d %H:%M")
 
+
 def mark_up(x):
     return round(x * 1.05, 2)
+
 
 def mark_down(x):
     return round(x * 0.95, 2)
 
+
 def has_timezone(date: dt.datetime) -> bool:
     return date.tzinfo is not None and date.tzinfo.utcoffset(date) is not None
+
 
 # def set_system_timezone(date: dt.datetime) -> dt.datetime:
 #     """
@@ -181,6 +190,7 @@ def has_timezone(date: dt.datetime) -> bool:
 #     """
 #     timezone = pytz.timezone(str(tzlocal.get_localzone()))
 #     return timezone.localize(date).astimezone(pytz.utc)
+
 
 class Timestamp:
     def __init__(self, *args) -> None:
@@ -198,6 +208,7 @@ class Timestamp:
     def __sub__(self, other):
         return Timerange(self.timestamp - other.timestamp)
 
+
 class Timerange:
     def __init__(self, *args) -> None:
         if len(args) == 1:
@@ -211,22 +222,24 @@ class Timerange:
             dict = {range_list[i]: arg for i, arg in enumerate(args)}
             self.timerange = dt.timedelta(**dict)
 
-def _convert_input_to_datetime(datetime, timezone:ZoneInfo):
-     
-        if datetime is None:
-            return None 
-        elif isinstance(datetime, Timestamp):
-            datetime = tz.localize(datetime.timestamp)
-        elif isinstance(datetime, str):
-            datetime = str_to_datetime(datetime)
-        elif isinstance(datetime, dt.datetime):
-            datetime = tz.localize(datetime)
-        else:
-            raise ValueError(f"Cannot convert {datetime} to datetime.")
 
-        datetime = datetime.replace(tzinfo=timezone)
-        datetime = datetime.astimezone(tz.utc)
-    
+def _convert_input_to_datetime(datetime, timezone: ZoneInfo):
+
+    if datetime is None:
+        return None
+    elif isinstance(datetime, Timestamp):
+        datetime = tz.localize(datetime.timestamp)
+    elif isinstance(datetime, str):
+        datetime = str_to_datetime(datetime)
+    elif isinstance(datetime, dt.datetime):
+        datetime = tz.localize(datetime)
+    else:
+        raise ValueError(f"Cannot convert {datetime} to datetime.")
+
+    datetime = datetime.replace(tzinfo=timezone)
+    datetime = datetime.astimezone(tz.utc)
+
+
 def _convert_input_to_timedelta(period):
     """Converts period into a timedelta object.
     Period can be a string, timedelta object, or a Timerange object."""
@@ -243,21 +256,22 @@ def _convert_input_to_timedelta(period):
     else:
         raise ValueError(f"Cannot convert {period} to timedelta.")
 
-def pandas_timestamp_to_local(df: pd.DataFrame, timezone:ZoneInfo) -> pd.DataFrame:
+
+def pandas_timestamp_to_local(df: pd.DataFrame, timezone: ZoneInfo) -> pd.DataFrame:
     """
-    Converts the timestamp of a dataframe to local time, represented as a 
+    Converts the timestamp of a dataframe to local time, represented as a
     timezone naive datetime object.
     """
     df.index = df.index.map(lambda x: datetime_utc_to_local(x, timezone))
     return df
 
-def datetime_utc_to_local(datetime: dt.datetime, timezone:ZoneInfo) -> dt.datetime:
+
+def datetime_utc_to_local(datetime: dt.datetime, timezone: ZoneInfo) -> dt.datetime:
     """
-    Converts a datetime object in UTC to local time, represented as a 
+    Converts a datetime object in UTC to local time, represented as a
     timezone naive datetime object.
     """
     return datetime.astimezone(timezone).replace(tzinfo=None)
-    
 
 
 ############ Functions used for testing #################

--- a/harvest/utils.py
+++ b/harvest/utils.py
@@ -31,7 +31,6 @@ class Interval(IntEnum):
     DAY_1 = auto()
 
 
-
 def interval_string_to_enum(str_interval: str):
     if str_interval == "15SEC":
         return Interval.SEC_15
@@ -155,6 +154,7 @@ def epoch_zero() -> dt.datetime:
 def date_to_str(day) -> str:
     return day.strftime("%Y-%m-%d")
 
+
 def str_to_date(day) -> str:
     return pytz.utc.localize(dt.datetime.strptime(day, "%Y-%m-%d"))
 
@@ -162,13 +162,17 @@ def str_to_datetime(date: str) -> dt.datetime:
     """
     :date: A string in the format YYYY-MM-DD hh:mm
     """
-    return pytz.utc.localize(dt.datetime.strptime(date, "%Y-%m-%d %H:%M"))
+    if len(date) <= 10:
+        return dt.datetime.strptime(date, "%Y-%m-%d")
+    return dt.datetime.strptime(date, "%Y-%m-%d %H:%M")
 
 def mark_up(x):
     return round(x * 1.05, 2)
 
+
 def mark_down(x):
     return round(x * 0.95, 2)
+
 
 def has_timezone(date: dt.datetime) -> bool:
     return date.tzinfo is not None and date.tzinfo.utcoffset(date) is not None
@@ -182,9 +186,7 @@ def set_system_timezone(date: dt.datetime) -> dt.datetime:
     timezone = pytz.timezone(str(tzlocal.get_localzone()))
     return timezone.localize(date).astimezone(pytz.utc)
 
-
-class Timestamp():
-    
+class Timestamp:
     def __init__(self, *args) -> None:
         if len(args) == 1:
             timestamp = args[1]
@@ -200,8 +202,8 @@ class Timestamp():
     def __sub__(self, other):
         return Timerange(self.timestamp - other.timestamp)
 
-class Timerange():
-    
+
+class Timerange:
     def __init__(self, *args) -> None:
         if len(args) == 1:
             timerange = args[1]
@@ -210,12 +212,43 @@ class Timerange():
             else:
                 raise ValueError(f"Invalid timestamp type {type(timerange)}")
         elif len(args) > 1:
-            range_list = ['days', 'hours', 'minutes']
+            range_list = ["days", "hours", "minutes"]
             dict = {range_list[i]: arg for i, arg in enumerate(args)}
             self.timerange = dt.timedelta(**dict)
 
+def _convert_input_to_datetime(datetime, tz="UTC"):
+        tz = pytz.timezone(tz)
+        if datetime is None:
+            return None 
+        elif isinstance(datetime, Timestamp):
+            datetime = tz.localize(datetime.timestamp)
+        elif isinstance(datetime, str):
+            datetime = str_to_datetime(datetime)
+        elif isinstance(datetime, dt.datetime):
+            datetime = tz.localize(datetime)
+        else:
+            raise ValueError(f"Cannot convert {datetime} to datetime.")
+
+        datetime = datetime.replace(tzinfo=tz)
+        datetime = datetime.astimezone(pytz.utc)
+    
+def _convert_input_to_timedelta(period):
+    """Converts period into a timedelta object.
+    Period can be a string, timedelta object, or a Timerange object."""
+    if period is None:
+        return None
+    elif isinstance(period, Timerange):
+        return period.timerange
+    elif isinstance(period, str):
+        val, unit = expand_string_interval(period)
+        return dt.timedelta(**{unit: val})
+    elif isinstance(period, dt.timedelta):
+        return period
+    else:
+        raise ValueError(f"Cannot convert {period} to timedelta.")
 
 ############ Functions used for testing #################
+
 
 def gen_data(symbol: str, points: int = 50) -> pd.DataFrame:
     n = now()
@@ -231,6 +264,7 @@ def gen_data(symbol: str, points: int = 50) -> pd.DataFrame:
     df.columns = pd.MultiIndex.from_product([[symbol], df.columns])
 
     return df
+
 
 def not_gh_action(func):
     def wrapper(*args, **kwargs):

--- a/harvest/utils.py
+++ b/harvest/utils.py
@@ -142,7 +142,7 @@ def now() -> dt.datetime:
     """
     Returns the current time precise to the minute in the UTC timezone
     """
-    return dt.datetime.utcnow(tzinfo=tz.utc).replace(microsecond=0, second=0)
+    return dt.datetime.now(tz.utc).replace(microsecond=0, second=0)
 
 def epoch_zero() -> dt.datetime:
     """

--- a/harvest/utils.py
+++ b/harvest/utils.py
@@ -30,6 +30,11 @@ class Interval(IntEnum):
     HR_1 = auto()
     DAY_1 = auto()
 
+class Timestamp():
+    pass
+
+class Timerange():
+    pass
 
 def interval_string_to_enum(str_interval: str):
     if str_interval == "15SEC":

--- a/harvest/utils.py
+++ b/harvest/utils.py
@@ -30,11 +30,7 @@ class Interval(IntEnum):
     HR_1 = auto()
     DAY_1 = auto()
 
-class Timestamp():
-    pass
 
-class Timerange():
-    pass
 
 def interval_string_to_enum(str_interval: str):
     if str_interval == "15SEC":
@@ -159,29 +155,23 @@ def epoch_zero() -> dt.datetime:
 def date_to_str(day) -> str:
     return day.strftime("%Y-%m-%d")
 
-
 def str_to_date(day) -> str:
     return pytz.utc.localize(dt.datetime.strptime(day, "%Y-%m-%d"))
 
-
 def str_to_datetime(date: str) -> dt.datetime:
     """
-    :date: A string in the format MM-DD-YYYY:HH:MM:SS
+    :date: A string in the format YYYY-MM-DD hh:mm
     """
-    return pytz.utc.localize(dt.datetime.strptime(date, "%m-%d-%Y:%H:%M:%S"))
-
+    return pytz.utc.localize(dt.datetime.strptime(date, "%Y-%m-%d %H:%M"))
 
 def mark_up(x):
     return round(x * 1.05, 2)
 
-
 def mark_down(x):
     return round(x * 0.95, 2)
 
-
 def has_timezone(date: dt.datetime) -> bool:
     return date.tzinfo is not None and date.tzinfo.utcoffset(date) is not None
-
 
 def set_system_timezone(date: dt.datetime) -> dt.datetime:
     """
@@ -193,8 +183,39 @@ def set_system_timezone(date: dt.datetime) -> dt.datetime:
     return timezone.localize(date).astimezone(pytz.utc)
 
 
-############ Functions used for testing #################
+class Timestamp():
+    
+    def __init__(self, *args) -> None:
+        if len(args) == 1:
+            timestamp = args[1]
+            if isinstance(timestamp, str):
+                self.timestamp = str_to_datetime(timestamp)
+            elif isinstance(timestamp, dt.datetime):
+                self.timestamp = timestamp
+            else:
+                raise ValueError(f"Invalid timestamp type {type(timestamp)}")
+        elif len(args) > 1:
+            self.timestamp = dt.datetime(*args)
 
+    def __sub__(self, other):
+        return Timerange(self.timestamp - other.timestamp)
+
+class Timerange():
+    
+    def __init__(self, *args) -> None:
+        if len(args) == 1:
+            timerange = args[1]
+            if isinstance(timerange, dt.timedelta):
+                self.timerange = timerange
+            else:
+                raise ValueError(f"Invalid timestamp type {type(timerange)}")
+        elif len(args) > 1:
+            range_list = ['days', 'hours', 'minutes']
+            dict = {range_list[i]: arg for i, arg in enumerate(args)}
+            self.timerange = dt.timedelta(**dict)
+
+
+############ Functions used for testing #################
 
 def gen_data(symbol: str, points: int = 50) -> pd.DataFrame:
     n = now()
@@ -210,7 +231,6 @@ def gen_data(symbol: str, points: int = 50) -> pd.DataFrame:
     df.columns = pd.MultiIndex.from_product([[symbol], df.columns])
 
     return df
-
 
 def not_gh_action(func):
     def wrapper(*args, **kwargs):

--- a/harvest/utils.py
+++ b/harvest/utils.py
@@ -5,7 +5,9 @@ import time
 import random
 import logging
 import datetime as dt
+from datetime import timezone as tz 
 from enum import IntEnum, auto
+from zoneinfo import ZoneInfo
 
 # External Imports
 import pytz
@@ -104,7 +106,6 @@ def interval_to_timedelta(interval: Interval) -> dt.timedelta:
     params = {expanded_units[unit]: value}
     return dt.timedelta(**params)
 
-
 def is_crypto(symbol: str) -> bool:
     return symbol[0] == "@"
 
@@ -141,22 +142,19 @@ def now() -> dt.datetime:
     """
     Returns the current time precise to the minute in the UTC timezone
     """
-    return pytz.utc.localize(dt.datetime.utcnow().replace(microsecond=0, second=0))
-
+    return dt.datetime.utcnow(tzinfo=tz.utc).replace(microsecond=0, second=0)
 
 def epoch_zero() -> dt.datetime:
     """
     Returns a datetime object corresponding to midnight 1/1/1970 UTC
     """
-    return pytz.utc.localize(dt.datetime(1970, 1, 1))
-
+    return dt.datetime(1970, 1, 1, tzinfo=tz.utc)
 
 def date_to_str(day) -> str:
     return day.strftime("%Y-%m-%d")
 
-
 def str_to_date(day) -> str:
-    return pytz.utc.localize(dt.datetime.strptime(day, "%Y-%m-%d"))
+    return dt.datetime.strptime(day, "%Y-%m-%d")
 
 def str_to_datetime(date: str) -> dt.datetime:
     """
@@ -169,22 +167,20 @@ def str_to_datetime(date: str) -> dt.datetime:
 def mark_up(x):
     return round(x * 1.05, 2)
 
-
 def mark_down(x):
     return round(x * 0.95, 2)
-
 
 def has_timezone(date: dt.datetime) -> bool:
     return date.tzinfo is not None and date.tzinfo.utcoffset(date) is not None
 
-def set_system_timezone(date: dt.datetime) -> dt.datetime:
-    """
-    :date: A python datetime object that does not have tzinfo set.
-    If tzinfo is set, an error will occur. Converts first to the
-    timezone of the user's system and then to UTC.
-    """
-    timezone = pytz.timezone(str(tzlocal.get_localzone()))
-    return timezone.localize(date).astimezone(pytz.utc)
+# def set_system_timezone(date: dt.datetime) -> dt.datetime:
+#     """
+#     :date: A python datetime object that does not have tzinfo set.
+#     If tzinfo is set, an error will occur. Converts first to the
+#     timezone of the user's system and then to UTC.
+#     """
+#     timezone = pytz.timezone(str(tzlocal.get_localzone()))
+#     return timezone.localize(date).astimezone(pytz.utc)
 
 class Timestamp:
     def __init__(self, *args) -> None:
@@ -202,7 +198,6 @@ class Timestamp:
     def __sub__(self, other):
         return Timerange(self.timestamp - other.timestamp)
 
-
 class Timerange:
     def __init__(self, *args) -> None:
         if len(args) == 1:
@@ -216,8 +211,8 @@ class Timerange:
             dict = {range_list[i]: arg for i, arg in enumerate(args)}
             self.timerange = dt.timedelta(**dict)
 
-def _convert_input_to_datetime(datetime, tz="UTC"):
-        tz = pytz.timezone(tz)
+def _convert_input_to_datetime(datetime, timezone:ZoneInfo):
+     
         if datetime is None:
             return None 
         elif isinstance(datetime, Timestamp):
@@ -229,8 +224,8 @@ def _convert_input_to_datetime(datetime, tz="UTC"):
         else:
             raise ValueError(f"Cannot convert {datetime} to datetime.")
 
-        datetime = datetime.replace(tzinfo=tz)
-        datetime = datetime.astimezone(pytz.utc)
+        datetime = datetime.replace(tzinfo=timezone)
+        datetime = datetime.astimezone(tz.utc)
     
 def _convert_input_to_timedelta(period):
     """Converts period into a timedelta object.

--- a/harvest/utils.py
+++ b/harvest/utils.py
@@ -235,12 +235,30 @@ def _convert_input_to_timedelta(period):
     elif isinstance(period, Timerange):
         return period.timerange
     elif isinstance(period, str):
+        expanded_units = {"DAY": "days", "HR": "hours", "MIN": "minutes"}
         val, unit = expand_string_interval(period)
-        return dt.timedelta(**{unit: val})
+        return dt.timedelta(**{expanded_units[unit]: val})
     elif isinstance(period, dt.timedelta):
         return period
     else:
         raise ValueError(f"Cannot convert {period} to timedelta.")
+
+def pandas_timestamp_to_local(df: pd.DataFrame, timezone:ZoneInfo) -> pd.DataFrame:
+    """
+    Converts the timestamp of a dataframe to local time, represented as a 
+    timezone naive datetime object.
+    """
+    df.index = df.index.map(lambda x: datetime_utc_to_local(x, timezone))
+    return df
+
+def datetime_utc_to_local(datetime: dt.datetime, timezone:ZoneInfo) -> dt.datetime:
+    """
+    Converts a datetime object in UTC to local time, represented as a 
+    timezone naive datetime object.
+    """
+    return datetime.astimezone(timezone).replace(tzinfo=None)
+    
+
 
 ############ Functions used for testing #################
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,14 +14,14 @@ classifiers =
 
 [options]
 packages = find:
-python_requires = >=3.8
+python_requires = >=3.9
 install_requires =
-    pandas
-    finta
+    pandas >=1.3.0
+    finta >= 1.3
     pyyaml
     tqdm
-    pytz
-    tzlocal
+    tzlocal >=3.0
+    tzdata
     yfinance
     SQLAlchemy
     flask-cors

--- a/tests/test_algo.py
+++ b/tests/test_algo.py
@@ -4,7 +4,7 @@ import unittest
 from unittest.mock import patch
 
 # from harvest import algo
-from harvest.trader import Trader
+from harvest.trader import PaperTrader
 from harvest.api.dummy import DummyStreamer
 from harvest.algo import BaseAlgo
 
@@ -17,7 +17,7 @@ prices = [10, 12, 11, 9, 8, 10, 11, 12, 13, 15, 14, 16, 13, 14]
 
 class TestAlgo(unittest.TestCase):
 
-    # Watchlist set in the Algo class locally should take precendance over watchlist in Trader class
+    # Watchlist set in the Algo class locally should take precendance over watchlist in PaperTrader class
     def test_config_watchlist_1(self):
         class Algo1(BaseAlgo):
             def config(self):
@@ -31,7 +31,7 @@ class TestAlgo(unittest.TestCase):
         algo2 = Algo2()
 
         s = DummyStreamer()
-        t = Trader(s)
+        t = PaperTrader(s)
         t.set_algo([algo1, algo2])
         t.set_symbol(["1", "2", "3"])
 
@@ -51,7 +51,7 @@ class TestAlgo(unittest.TestCase):
             prices1, list(t.storage.load("A", Interval.MIN_5)["A"]["close"])
         )
 
-    # Trader class should be able to run algorithms at the individually specified intervals
+    # PaperTrader class should be able to run algorithms at the individually specified intervals
     def test_config_interval(self):
         class Algo1(BaseAlgo):
             def config(self):
@@ -69,7 +69,7 @@ class TestAlgo(unittest.TestCase):
         algo2 = Algo2()
 
         s = DummyStreamer()
-        t = Trader(s)
+        t = PaperTrader(s)
         t.set_algo([algo1, algo2])
 
         t.start()
@@ -134,10 +134,10 @@ class TestAlgo(unittest.TestCase):
 
     def test_bbands_trader(self):
         """
-        Test that bband values are calculated correctly based on data in Trader's Storage class.
+        Test that bband values are calculated correctly based on data in PaperTrader's Storage class.
         """
         streamer = DummyStreamer()
-        t = Trader(streamer)
+        t = PaperTrader(streamer)
         t.set_symbol("DUMMY")
         t.set_algo(BaseAlgo())
         t.start("1MIN")
@@ -149,7 +149,7 @@ class TestAlgo(unittest.TestCase):
 
     def test_get_asset_quantity(self):
         s = DummyStreamer()
-        t = Trader(s)
+        t = PaperTrader(s)
         t.set_symbol("A")
         t.set_algo(BaseAlgo())
         t.start("1MIN")
@@ -164,7 +164,7 @@ class TestAlgo(unittest.TestCase):
 
     def test_get_asset_cost(self):
         s = DummyStreamer()
-        t = Trader(s)
+        t = PaperTrader(s)
         t.set_symbol("A")
         t.set_algo(BaseAlgo())
         t.start("1MIN")
@@ -179,7 +179,7 @@ class TestAlgo(unittest.TestCase):
 
     def test_get_asset_price(self):
         s = DummyStreamer()
-        t = Trader(s)
+        t = PaperTrader(s)
         t.set_symbol("A")
         t.set_algo(BaseAlgo())
         t.start("1MIN")
@@ -195,7 +195,7 @@ class TestAlgo(unittest.TestCase):
 
     def test_buy_sell(self):
         s = DummyStreamer()
-        t = Trader(s)
+        t = PaperTrader(s)
         t.set_symbol("A")
         t.set_algo(BaseAlgo())
         t.start("1MIN")
@@ -218,7 +218,7 @@ class TestAlgo(unittest.TestCase):
 
     def test_buy_sell_auto(self):
         s = DummyStreamer()
-        t = Trader(s)
+        t = PaperTrader(s)
         t.set_symbol("A")
         t.set_algo(BaseAlgo())
         t.start("1MIN")
@@ -242,7 +242,7 @@ class TestAlgo(unittest.TestCase):
         mock_mark_up.return_value = 10
 
         streamer = DummyStreamer()
-        t = Trader(streamer)
+        t = PaperTrader(streamer)
         t.set_symbol("X")
         t.set_algo(BaseAlgo())
         t.start("1MIN")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -9,7 +9,7 @@ import pandas as pd
 
 from harvest.api._base import StreamAPI
 from harvest.api.dummy import DummyStreamer
-from harvest.trader import Trader
+from harvest.trader import PaperTrader
 from harvest.utils import *
 
 
@@ -25,7 +25,7 @@ class TestAPI(unittest.TestCase):
         stream.fetch_account = lambda: None
         stream.fetch_price_history = lambda x, y: pd.DataFrame()
         stream.fetch_account = lambda: {"cash": 100, "equity": 100}
-        t = Trader(stream)
+        t = PaperTrader(stream)
         stream.trader = t
         stream.trader_main = t.main
         t.set_symbol(["A", "B"])
@@ -75,7 +75,7 @@ class TestAPI(unittest.TestCase):
         stream.fetch_account = lambda: None
         stream.fetch_price_history = lambda x, y: pd.DataFrame()
         stream.fetch_account = lambda: {"cash": 100, "equity": 100}
-        t = Trader(stream)
+        t = PaperTrader(stream)
         stream.trader = t
         stream.trader_main = t.main
         t.set_symbol(["A", "B"])

--- a/tests/test_api_polygon.py
+++ b/tests/test_api_polygon.py
@@ -8,7 +8,6 @@ from harvest.api.polygon import PolygonStreamer
 
 
 class TestPolygonStreamer(unittest.TestCase):
-
     @not_gh_action
     def test_fetch_prices(self):
         poly = PolygonStreamer("poly_secret.yaml", True)

--- a/tests/test_api_webull.py
+++ b/tests/test_api_webull.py
@@ -5,13 +5,12 @@ import datetime as dt
 import os
 
 from harvest.utils import not_gh_action
-from harvest.api.webull import Webull
-
 
 class TestWebull(unittest.TestCase):
 
     @not_gh_action
     def test_fetch_prices(self):
+        from harvest.api.webull import Webull
         wb = Webull()
         df = wb.fetch_price_history("SPY", interval="1MIN")["SPY"]
         self.assertEqual(
@@ -21,6 +20,7 @@ class TestWebull(unittest.TestCase):
 
     @not_gh_action
     def test_setup(self):
+        from harvest.api.webull import Webull
         wb = Webull()
         watch = ["SPY", "AAPL", "@BTC", "@ETH"]
         wb.setup(watch, "1MIN")
@@ -30,6 +30,7 @@ class TestWebull(unittest.TestCase):
 
     @not_gh_action
     def test_main(self):
+        from harvest.api.webull import Webull
         def test_main(df):
             self.assertEqual(len(df), 3)
             self.assertEqual(df["SPY"].columns[0][0], "SPY")
@@ -43,6 +44,7 @@ class TestWebull(unittest.TestCase):
 
     @not_gh_action
     def test_main_single(self):
+        from harvest.api.webull import Webull
         def test_main(df):
             self.assertEqual(len(df), 1)
             self.assertEqual(df["SPY"].columns[0][0], "SPY")
@@ -54,6 +56,7 @@ class TestWebull(unittest.TestCase):
 
     @not_gh_action
     def test_chain_info(self):
+        from harvest.api.webull import Webull
         wb = Webull()
         watch = ["SPY"]
         wb.setup(watch, "1MIN", None, None)
@@ -62,6 +65,7 @@ class TestWebull(unittest.TestCase):
 
     @not_gh_action
     def test_chain_data(self):
+        from harvest.api.webull import Webull
         wb = Webull()
         watch = ["LMND"]
         wb.setup(watch, "1MIN", None, None)

--- a/tests/test_api_webull.py
+++ b/tests/test_api_webull.py
@@ -7,6 +7,7 @@ import os
 from harvest.utils import not_gh_action
 from harvest.api.webull import Webull
 
+
 class TestWebull(unittest.TestCase):
     def not_gh_action(func):
         def wrapper(*args, **kwargs):

--- a/tests/test_api_webull.py
+++ b/tests/test_api_webull.py
@@ -6,11 +6,12 @@ import os
 
 from harvest.utils import not_gh_action
 
-class TestWebull(unittest.TestCase):
 
+class TestWebull(unittest.TestCase):
     @not_gh_action
     def test_fetch_prices(self):
         from harvest.api.webull import Webull
+
         wb = Webull()
         df = wb.fetch_price_history("SPY", interval="1MIN")["SPY"]
         self.assertEqual(
@@ -21,6 +22,7 @@ class TestWebull(unittest.TestCase):
     @not_gh_action
     def test_setup(self):
         from harvest.api.webull import Webull
+
         wb = Webull()
         watch = ["SPY", "AAPL", "@BTC", "@ETH"]
         wb.setup(watch, "1MIN")
@@ -31,6 +33,7 @@ class TestWebull(unittest.TestCase):
     @not_gh_action
     def test_main(self):
         from harvest.api.webull import Webull
+
         def test_main(df):
             self.assertEqual(len(df), 3)
             self.assertEqual(df["SPY"].columns[0][0], "SPY")
@@ -45,6 +48,7 @@ class TestWebull(unittest.TestCase):
     @not_gh_action
     def test_main_single(self):
         from harvest.api.webull import Webull
+
         def test_main(df):
             self.assertEqual(len(df), 1)
             self.assertEqual(df["SPY"].columns[0][0], "SPY")
@@ -57,6 +61,7 @@ class TestWebull(unittest.TestCase):
     @not_gh_action
     def test_chain_info(self):
         from harvest.api.webull import Webull
+
         wb = Webull()
         watch = ["SPY"]
         wb.setup(watch, "1MIN", None, None)
@@ -66,6 +71,7 @@ class TestWebull(unittest.TestCase):
     @not_gh_action
     def test_chain_data(self):
         from harvest.api.webull import Webull
+
         wb = Webull()
         watch = ["LMND"]
         wb.setup(watch, "1MIN", None, None)

--- a/tests/test_api_webull.py
+++ b/tests/test_api_webull.py
@@ -9,13 +9,6 @@ from harvest.api.webull import Webull
 
 
 class TestWebull(unittest.TestCase):
-    def not_gh_action(func):
-        def wrapper(*args, **kwargs):
-            if "GITHUB_ACTION" in os.environ:
-                return
-            func(*args, **kwargs)
-
-        return wrapper
 
     @not_gh_action
     def test_fetch_prices(self):

--- a/tests/test_trader.py
+++ b/tests/test_trader.py
@@ -3,7 +3,7 @@ import unittest
 import time
 
 # Submodule imports
-from harvest.trader import Trader
+from harvest.trader import PaperTrader
 from harvest.algo import BaseAlgo
 from harvest.api.dummy import DummyStreamer
 from harvest.api.paper import PaperBroker
@@ -15,14 +15,14 @@ import datetime as dt
 from harvest.utils import gen_data
 
 
-class TestTrader(unittest.TestCase):
+class TestPaperTrader(unittest.TestCase):
     def test_trader_adding_symbol(self):
-        t = Trader(DummyStreamer())
+        t = PaperTrader(DummyStreamer())
         t.set_symbol("A")
         self.assertEqual(t.watchlist_global[0], "A")
 
     def test_start_do_nothing(self):
-        t = Trader(DummyStreamer())
+        t = PaperTrader(DummyStreamer())
         t.set_symbol("A")
         t.set_algo(BaseAlgo())
         t.start("1MIN")
@@ -34,7 +34,7 @@ class TestTrader(unittest.TestCase):
         If streamer is not specified, by default
         it should be set to DummyStreamer, and broker set to
         """
-        t = Trader(DummyStreamer())
+        t = PaperTrader(DummyStreamer())
 
         self.assertIsInstance(t.streamer, DummyStreamer)
         self.assertIsInstance(t.broker, PaperBroker)
@@ -42,21 +42,21 @@ class TestTrader(unittest.TestCase):
     # def test_broker_set(self):
     #     """If a single API class is set, it should be set as
     #     a streamer and a broker"""
-    #     t = Trader( Robinhood() )
+    #     t = PaperTrader( Robinhood() )
 
     #     self.assertIsInstance(t.streamer, Robinhood)
     #     self.assertIsInstance(t.broker, Robinhood)
 
     def test_dummy_streamer(self):
         """If streamer is DummyStreamer, broker should be PaperBroker"""
-        t = Trader(DummyStreamer())
+        t = PaperTrader(DummyStreamer())
 
         self.assertIsInstance(t.streamer, DummyStreamer)
         self.assertIsInstance(t.broker, PaperBroker)
 
     def test_invalid_aggregation(self):
         """If invalid aggregation is set, it should raise an error"""
-        t = Trader(DummyStreamer())
+        t = PaperTrader(DummyStreamer())
         with self.assertRaises(Exception):
             t.start("30MIN", ["5MIN", "1DAY"])
 


### PR DESCRIPTION
Makes the following changes:
- Implements the `Timestamp` and `Timerange` class. However, during development it became evident that the classes did not provide much advantage. As such they are only half-implemented, and may even be removed in the future. A better alternative would be to provide helper functions to manipulate time, or extend the DateTime objects instead of wrapping it. 
- Interfaces that take dates as input can take strings, DateTime objects, or Timestamp objects. Again, the third option may be removed in the future.
- Implemented few updates to the interface mentioned in #166. Updated tests accordingly.
- Implemented time zones. For timezone information, ZoneInfo class is used instead of pytz, as it comes built in with Python 3.9 and is also supported by the latest version of tzlocal. 
- **Harvest now only supports Python 3.9 or higher.**