### PR TITLE
Fix dummy streamer

### DIFF
--- a/harvest/api/dummy.py
+++ b/harvest/api/dummy.py
@@ -37,8 +37,6 @@ class DummyStreamer(API):
         realistic_times: bool = False,
     ):
 
-        # super().__init__(None)
-
         self.trader_main = None
         self.realistic_times = realistic_times
 
@@ -50,7 +48,7 @@ class DummyStreamer(API):
         self.randomness = {}
 
     def start(self) -> None:
-        pass
+        super().start()
 
     def main(self):
         df_dict = {}

--- a/harvest/trader/trader.py
+++ b/harvest/trader/trader.py
@@ -68,7 +68,12 @@ class LiveTrader:
 
     def _init_attributes(self):
 
-        signal(SIGINT, self.exit)
+        try:
+            signal(SIGINT, self.exit)
+        except:
+            debugger.warning(
+                "Can't use signal, Harvest is running in a non-main thread."
+            )
 
         self.watchlist = []  # List of securities specified in this class
         self.algo = []  # List of algorithms to run.

--- a/harvest/utils.py
+++ b/harvest/utils.py
@@ -721,7 +721,12 @@ def pandas_timestamp_to_local(df: pd.DataFrame, timezone: ZoneInfo) -> pd.DataFr
     """
     Converts the timestamp of a Pandas dataframe to a timezone naive DateTime object in local time.
     """
-    df.index = df.index.map(lambda x: datetime_utc_to_local(x, timezone))
+    df.index = pd.DatetimeIndex(
+        map(
+            lambda x: x.astimezone(timezone).replace(tzinfo=None),
+            df.index.to_pydatetime(),
+        )
+    )
     return df
 
 

--- a/harvest/utils.py
+++ b/harvest/utils.py
@@ -721,7 +721,7 @@ def pandas_timestamp_to_local(df: pd.DataFrame, timezone: ZoneInfo) -> pd.DataFr
     """
     Converts the timestamp of a Pandas dataframe to a timezone naive DateTime object in local time.
     """
-    df.index = df.index.map(lambda x: datetime_utc_to_local(x, timezone))
+    df.index = df.index.map(lambda x: pd.DatetimeIndex([datetime_utc_to_local(x, timezone)]))
     return df
 
 
@@ -741,8 +741,8 @@ def datetime_utc_to_local(date_time: dt.datetime, timezone: ZoneInfo) -> dt.date
     """
     # If date_time is a Dataframe timestamp, we must first convert to a normal Datetime object
     if not isinstance(date_time, dt.datetime):
-        date_time = date_time.to_pydatetime()
-
+        date_time = date_time.to_pydatetime()[0]
+        
     new_tz = date_time.astimezone(timezone)
     return new_tz.replace(tzinfo=None)
 

--- a/harvest/utils.py
+++ b/harvest/utils.py
@@ -721,7 +721,7 @@ def pandas_timestamp_to_local(df: pd.DataFrame, timezone: ZoneInfo) -> pd.DataFr
     """
     Converts the timestamp of a Pandas dataframe to a timezone naive DateTime object in local time.
     """
-    df.index = df.index.map(lambda x: pd.DatetimeIndex([datetime_utc_to_local(x, timezone)]))
+    df.index = df.index.map(lambda x: datetime_utc_to_local(x, timezone))
     return df
 
 
@@ -741,8 +741,8 @@ def datetime_utc_to_local(date_time: dt.datetime, timezone: ZoneInfo) -> dt.date
     """
     # If date_time is a Dataframe timestamp, we must first convert to a normal Datetime object
     if not isinstance(date_time, dt.datetime):
-        date_time = date_time.to_pydatetime()[0]
-        
+        date_time = date_time.to_pydatetime()
+
     new_tz = date_time.astimezone(timezone)
     return new_tz.replace(tzinfo=None)
 

--- a/tests/unittest/test_algo.py
+++ b/tests/unittest/test_algo.py
@@ -37,6 +37,8 @@ class TestAlgo(unittest.TestCase):
         algo2 = Algo2()
 
         s = DummyStreamer()
+        # Prevent streamer from running which will cause an infinite loop
+        s.start = lambda: None
         t = PaperTrader(s)
         t.set_algo([algo1, algo2])
         t.set_symbol(["1", "2", "3"])
@@ -80,6 +82,8 @@ class TestAlgo(unittest.TestCase):
         algo2 = Algo2()
 
         s = DummyStreamer()
+        # Prevent streamer from running which will cause an infinite loop
+        s.start = lambda: None
         t = PaperTrader(s)
         t.set_algo([algo1, algo2])
 
@@ -179,6 +183,8 @@ class TestAlgo(unittest.TestCase):
         Test that bband values are calculated correctly based on data in PaperTrader's Storage class.
         """
         streamer = DummyStreamer()
+        # Prevent streamer from running which will cause an infinite loop
+        streamer.start = lambda: None
         t = PaperTrader(streamer)
         t.set_symbol("DUMMY")
         t.set_algo(BaseAlgo())
@@ -196,6 +202,8 @@ class TestAlgo(unittest.TestCase):
 
     def test_get_asset_quantity(self):
         s = DummyStreamer()
+        # Prevent streamer from running which will cause an infinite loop
+        s.start = lambda: None
         t = PaperTrader(s)
         t.set_symbol("A")
         t.set_algo(BaseAlgo())
@@ -217,6 +225,8 @@ class TestAlgo(unittest.TestCase):
 
     def test_get_asset_cost(self):
         s = DummyStreamer()
+        # Prevent streamer from running which will cause an infinite loop
+        s.start = lambda: None
         t = PaperTrader(s)
         t.set_symbol("A")
         t.set_algo(BaseAlgo())
@@ -238,6 +248,8 @@ class TestAlgo(unittest.TestCase):
 
     def test_get_asset_price(self):
         s = DummyStreamer()
+        # Prevent streamer from running which will cause an infinite loop
+        s.start = lambda: None
         t = PaperTrader(s)
         t.set_symbol("A")
         t.set_algo(BaseAlgo())
@@ -260,6 +272,8 @@ class TestAlgo(unittest.TestCase):
 
     def test_buy_sell(self):
         s = DummyStreamer()
+        # Prevent streamer from running which will cause an infinite loop
+        s.start = lambda: None
         t = PaperTrader(s)
         t.set_symbol("A")
         t.set_algo(BaseAlgo())
@@ -289,6 +303,8 @@ class TestAlgo(unittest.TestCase):
 
     def test_buy_sell_auto(self):
         s = DummyStreamer()
+        # Prevent streamer from running which will cause an infinite loop
+        s.start = lambda: None
         t = PaperTrader(s)
         t.set_symbol("A")
         t.set_algo(BaseAlgo())
@@ -319,6 +335,8 @@ class TestAlgo(unittest.TestCase):
         mock_mark_up.return_value = 10
 
         streamer = DummyStreamer()
+        # Prevent streamer from running which will cause an infinite loop
+        streamer.start = lambda: None
         t = PaperTrader(streamer, debug=True)
         t.set_symbol("X")
         t.set_algo(BaseAlgo())

--- a/tests/unittest/test_tester.py
+++ b/tests/unittest/test_tester.py
@@ -27,6 +27,8 @@ class TestTester(unittest.TestCase):
         to ensure it can run without crashing.
         """
         s = DummyStreamer()
+        # Prevent streamer from running which will cause an infinite loop
+        s.start = lambda: None
         t = BackTester(s, True)
         t.set_symbol("A")
         t.set_algo(BaseAlgo())
@@ -37,7 +39,10 @@ class TestTester(unittest.TestCase):
     @tear_up_down
     def test_check_aggregation(self):
         """ """
-        t = BackTester(DummyStreamer(), True)
+        s = DummyStreamer()
+        # Prevent streamer from running which will cause an infinite loop
+        s.start = lambda: None
+        t = BackTester(s, True)
         t.set_symbol("A")
         t.set_algo(BaseAlgo())
         t.start("1MIN", ["1DAY"], period="2DAY")
@@ -57,7 +62,10 @@ class TestTester(unittest.TestCase):
             def main(self):
                 print(self.get_datetime())
 
-        t = BackTester(DummyStreamer())
+        s = DummyStreamer()
+        # Prevent streamer from running which will cause an infinite loop
+        s.start = lambda: None
+        t = BackTester()
         t.set_symbol("A")
         t.set_algo(TestAlgo())
         t.start("1MIN", ["1DAY"], period="2DAY")

--- a/tests/unittest/test_trader.py
+++ b/tests/unittest/test_trader.py
@@ -27,7 +27,10 @@ class TestPaperTrader(unittest.TestCase):
             pass
 
     def test_start_do_nothing(self):
-        t = PaperTrader(DummyStreamer())
+        s = DummyStreamer()
+        # Prevent streamer from running which will cause an infinite loop
+        s.start = lambda: None
+        t = PaperTrader(s)
         t.set_symbol("A")
         t.set_algo(BaseAlgo())
         t.start("1MIN")
@@ -44,6 +47,7 @@ class TestPaperTrader(unittest.TestCase):
         If streamer is not specified, by default
         it should be set to DummyStreamer, and broker set to
         """
+
         t = PaperTrader(DummyStreamer())
 
         self.assertIsInstance(t.streamer, DummyStreamer)
@@ -76,7 +80,10 @@ class TestPaperTrader(unittest.TestCase):
 
     def test_invalid_aggregation(self):
         """If invalid aggregation is set, it should raise an error"""
-        t = PaperTrader(DummyStreamer())
+        s = DummyStreamer()
+        # Prevent streamer from running which will cause an infinite loop
+        s.start = lambda: None
+        t = PaperTrader(s)
         with self.assertRaises(Exception):
             t.start("30MIN", ["5MIN", "1DAY"])
 


### PR DESCRIPTION
Currently the dummy streamer does not actual do anything when `start` is called. This fixes that and updates tests so that they do not break.